### PR TITLE
Fix for date parsing in old exif

### DIFF
--- a/backend/timeline/api/assets.py
+++ b/backend/timeline/api/assets.py
@@ -22,6 +22,7 @@ import io
 from flask import Blueprint, abort
 from timeline.extensions import celery
 
+from timeline.api.util import parse_exif_date
 from timeline.tasks.crud_tasks import create_preview
 from timeline.util.image_ops import exif_transpose
 import logging
@@ -253,7 +254,7 @@ def upload():
 
                 try:
                     # set asset date
-                    dt = datetime.datetime.strptime(str(date_time), "%Y:%m:%d %H:%M:%S")
+                    dt = parse_exif_date(date_time)
                 except ValueError:
                     logger.error("%s can not be parsed as Date for %s",
                                 str(date_time), filename)

--- a/backend/timeline/api/util.py
+++ b/backend/timeline/api/util.py
@@ -15,6 +15,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 '''
 
+from datetime import datetime
 import flask
 from timeline.domain import (GPS, Face, Person, Asset, Section, Status, Thing,
                              asset_thing, Exif, asset_album, Album)
@@ -70,3 +71,21 @@ def assets_from_smart_album(album: Album, q = None):
                 camera = album.camera_make, fromDate = album.start_date, toDate = album.end_date,
                 rating = album.rating)
     return q
+
+
+def parse_exif_date(value:str):
+    if not value:
+        return None
+    # Removing excessive characters from some old exif
+    dateStr = str(value).strip("\x00\r\n ")
+    try:
+        dt = datetime.strptime(str(dateStr), "%Y:%m:%d %H:%M:%S")
+    except ValueError:
+        try:
+            dt = datetime.strptime(str(dateStr), "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            try:
+                dt = datetime.strptime(str(dateStr), "%Y/%m/%d %H:%M:%S")
+            except ValueError:
+                raise
+    return dt


### PR DESCRIPTION
Some old exif files has date stamps with spaces and 0x00 - which might be exif reader errors, but I am adding a workaround to clear them out.
Also they are in the different date format - may me because they were taken in Europe, adding several other date formats - with '-' and '/'