### PR TITLE
Recent processed faces

### DIFF
--- a/frontend/src/components/ImageViewer.vue
+++ b/frontend/src/components/ImageViewer.vue
@@ -162,15 +162,18 @@
                             <div>
                                 <v-card-text>
                                     <div class="font-weight-bold">Details</div>
-                                <v-list-item two-line>
+                                <v-list-item three-line>
                                     <v-list-item-avatar>
-                                        <v-icon>mdi-calendar</v-icon>
+                                        <v-icon>mdi-folder</v-icon>
                                     </v-list-item-avatar>
                                     <v-list-item-content>
                                         <v-list-item-title v-html="date(photo.created)"></v-list-item-title>
                                         <v-list-item-subtitle v-html="time(photo.created)"></v-list-item-subtitle>
                                     </v-list-item-content>
-                                </v-list-item>
+                                    <v-list-item-subtitle class="d-flex text-wrap">
+                                        {{photo.directory}}
+                                    </v-list-item-subtitle>
+                            </v-list-item>
                                 <!-- repair this; information is also available for Videos but not as exif -->
                                 <v-list-item two-line v-if="isPhoto">
                                     <v-list-item-avatar>

--- a/frontend/src/components/PersonsView.vue
+++ b/frontend/src/components/PersonsView.vue
@@ -47,7 +47,7 @@
             <v-row>
                 <v-col>
                     <v-pagination
-                        v-model="pageConfirm"
+                        v-model="pageKnown"
                         :length="persons.pages"
                     ></v-pagination>
                 </v-col>
@@ -71,7 +71,7 @@
                 <v-col
                     v-for="face in facesToConfirm.items" :key="face.id" class="d-flex child-flex"
                     xs="3" md="2" lg="2" xl="1">
-                    <face-view @update="updateFacesToConfirm" :face="face" :selectorText="'Correct?'"></face-view>
+                    <face-view @update="updateFacesToConfirm" :face="face" :selectorText="'Correct?'" :showAssetStamp="true" :showDistance="true"></face-view>
                 </v-col>
             </v-row>
             <v-row>
@@ -125,7 +125,7 @@
             <v-row>
                 <v-col>
                     <v-pagination
-                        v-model="page"
+                        v-model="pageUnknown"
                         :length="unknownFaces.pages"
                         
                     ></v-pagination>
@@ -187,10 +187,12 @@
         data() {
             return {
                 tab: 'groups',
-                size: 24,
-                page: 1,
+                sizeKnown: 24,
+                pageKnown: 1,
                 sizeConfirm: 24,
                 pageConfirm: 1,
+                sizeUnknown: 24,
+                pageUnknown: 1,
                 sizeRecent: 48,
                 pageRecent: 1,
                 hoverIgnoreAll: false
@@ -199,18 +201,21 @@
 
         mounted() {
             this.$store.dispatch("getAllPersons");
-            this.$store.dispatch("getPersons", {page: this.page, size: this.size});
+            this.$store.dispatch("getPersons", {page: this.pageKnown, size: this.sizeKnown});
             this.$store.dispatch("getKnownPersons");
-            this.$store.dispatch("getAllUnknownFaces", {page: this.page, size: this.size});
-            this.$store.dispatch("getFacesToConfirm", {page: this.page, size: this.size});
-            this.$store.dispatch("getRecentFaces", {page: 1, size: this.size});
-            this.$store.dispatch("getMostRecentFaces", {size: this.size});
+            this.$store.dispatch("getAllUnknownFaces", {page: this.pageUnknown, size: this.sizeUnknown});
+            this.$store.dispatch("getFacesToConfirm", {page: this.pageConfirm, size: this.sizeConfirm});
+            this.$store.dispatch("getRecentFaces", {page: 1, size: this.sizeRecent});
+            this.$store.dispatch("getMostRecentFaces", {size: this.sizeRecent});
             this.setFacesSeen();
         },
 
         watch: {
-            page(val) {
-                this.$store.dispatch("getAllUnknownFaces", {page: val, size: this.size});
+            pageKnown(val) {
+                this.$store.dispatch("getPersons", {page: val, size: this.sizeKnown});
+            }, 
+            pageUnknown(val) {
+                this.$store.dispatch("getAllUnknownFaces", {page: val, size: this.sizeUnknown});
             }, 
             pageConfirm(val) {
                 this.$store.dispatch("getFacesToConfirm", {page: val, size: this.sizeConfirm});
@@ -221,7 +226,7 @@
 
             tab(v) {
                 if (v == "unknown")
-                    this.$store.dispatch("getAllUnknownFaces", {page: this.page, size: this.size});
+                    this.$store.dispatch("getAllUnknownFaces", {page: this.pageUnknown, size: this.sizeUnknown});
             }
 
         },
@@ -244,10 +249,10 @@
             },
 
             updateUnknownFaces() {
-                this.$store.dispatch("getAllUnknownFaces", {page: this.page, size: this.size});
+                this.$store.dispatch("getAllUnknownFaces", {page: this.pageUnknown, size: this.sizeUnknown});
                 this.$store.dispatch("getAllPersons");
-                this.$store.dispatch("getPersons", {page: this.page, size: this.size});
-                this.$store.dispatch("getMostRecentFaces", {size: this.size});
+                this.$store.dispatch("getPersons", {page: this.pageKnown, size: this.sizeKnown});
+                this.$store.dispatch("getMostRecentFaces", {size: this.sizeRecent});
             },
 
             updateFacesToConfirm() {
@@ -263,9 +268,9 @@
                 this.unknownFaces.items.forEach( faceInfo => {
                     this.$store.dispatch("ignoreFace", faceInfo);
                 });
-                this.$store.dispatch("getPersons", {page: this.page, size: this.size});
-                this.$store.dispatch("getMostRecentFaces", {size: this.size});
-                this.$store.dispatch("getAllUnknownFaces", {page: this.page, size: this.size});
+                this.$store.dispatch("getPersons", {page: this.pageKnown, size: this.sizeKnown});
+                this.$store.dispatch("getMostRecentFaces", {size: this.sizeRecent});
+                this.$store.dispatch("getAllUnknownFaces", {page: this.pageUnknown, size: this.sizeUnknown});
                 this.$emit("update");
                 this.close();
             }

--- a/frontend/src/store/person.js
+++ b/frontend/src/store/person.js
@@ -7,6 +7,7 @@ export const person = {
         knownPersons: [],
         unknownFaces: [],
         recentFaces: [],
+        mostRecentFaces: [],
         facesToConfirm: [],
         markMode: false,
         previewHeight: 100,
@@ -32,6 +33,9 @@ export const person = {
         },
         setRecentFaces(state, recent) {
             state.recentFaces = recent;
+        },
+        setMostRecentFaces(state, recent) {
+            state.mostRecentFaces = recent;
         },
         setFacesToConfirm(state, unknown) {
             state.facesToConfirm = unknown;
@@ -115,6 +119,14 @@ export const person = {
             let url = `/api/face/recent/${page}/${size}`;
             axios.get(url).then( result => {
                 context.commit("setRecentFaces", result.data);    
+            })
+            
+        },
+
+        getMostRecentFaces(context, {size}) {
+            let url = `/api/face/recent/1/${size}`;
+            axios.get(url).then( result => {
+                context.commit("setMostRecentFaces", result.data);    
             })
             
         },


### PR DESCRIPTION
Adding new tab into People: Recent Faces.
Allows to see and managed identified faces, fix mistakes and reassign to the right Person.

Also fixing the pagination as it was using one variable for Known and Unknown tabs.